### PR TITLE
Update import syntax for relative files for python3

### DIFF
--- a/configlib/__init__.py
+++ b/configlib/__init__.py
@@ -1,4 +1,4 @@
-from configlib import getConfig
+from .configlib import getConfig
 from optparse import OptionParser
 
 __all__ = [getConfig, OptionParser]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     install_requires=requirements,
     tests_require=test_requirements,
     test_suite='tests',
-    version = '2.0.3',
+    version = '2.0.4',
     description = 'wrapper for ConfigParser allowing for simple get calls to set options.',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This allows support for python3.

It will require a new package be deployed.